### PR TITLE
fixed typos, better development default configs and settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# local development values file
+artemis/values-local.yaml
+
 # OSX thumbnails
 ._*
 

--- a/artemis/templates/configmaps/jhipster-registry-configmap.yml
+++ b/artemis/templates/configmaps/jhipster-registry-configmap.yml
@@ -23,7 +23,7 @@ data:
         authentication:
           jwt:
             # This is bad practice, but this value cannot be handed to the registry via the environment. Needs further investigation 
-            base64-secret: {{ required "Registry  JWT is required" .Values.application.registry.jwt | b64enc | quote }} 
+            base64-secret: {{ required "Registry JWT is required!" .Values.application.registry.jwt | b64enc | quote }}
   # app specific configuration
   jhipster-registry.yml: |-
     eureka:

--- a/artemis/templates/secrets/artemis-usermanagement-secrets.yml
+++ b/artemis/templates/secrets/artemis-usermanagement-secrets.yml
@@ -8,5 +8,5 @@ data:
   artemis.user-management.external.user: {{ required "Jira username is required" .Values.application.userManagement.jira.username | b64enc | quote }}
   artemis.user-management.external.password: {{ required "Jira password is required" .Values.application.userManagement.jira.password | b64enc | quote }}
   {{- end }}
-  artemis.user-management.internal-admin.username: {{ required "Interal admin username is required!" .Values.application.userManagement.internalAdmin.username | b64enc | quote}}
-  artemis.user-management.internal-admin.password: {{ required "Interal admin password is required!" .Values.application.userManagement.internalAdmin.password | b64enc | quote }}
+  artemis.user-management.internal-admin.username: {{ required "Internal admin username is required!" .Values.application.userManagement.internalAdmin.username | b64enc | quote }}
+  artemis.user-management.internal-admin.password: {{ required "Internal admin password is required!" .Values.application.userManagement.internalAdmin.password | b64enc | quote }}

--- a/artemis/values.yaml
+++ b/artemis/values.yaml
@@ -1,7 +1,7 @@
 # Default values for artemis.
 
-# Sepcify the Artemis verion 
-# This value is used as docker image tag, so also "pr-1234" is a valid value here. 
+# Specify the Artemis version
+# This value is used as docker image tag, so also "pr-1234" is a valid value here.
 # See https://github.com/ls1intum/Artemis/pkgs/container/artemis/versions
 artemisVersion: "5.5.7"
 
@@ -102,7 +102,7 @@ artemis:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: example.com 
+      - host: artemis.example
         paths:
           - path: /
             pathType: ImplementationSpecific


### PR DESCRIPTION
- fixed some typos
- added a "local" value file which is not under version control to fill this with sample values for testing
- `artemis.example` as default URL as this is not registered to anyone and can be changed in the `/etc/hosts` without issues if you want to use them for local testing